### PR TITLE
startup: add logging and remove lndclient

### DIFF
--- a/boltnd.go
+++ b/boltnd.go
@@ -16,6 +16,8 @@ type Boltnd struct {
 	stopped int32 // to be used atomically
 
 	rpcServer *rpcserver.Server
+
+	cfg *Config
 }
 
 // NewBoltnd returns a new external boltnd implementation. Note that the
@@ -44,6 +46,7 @@ func NewBoltnd(opts ...ConfigOption) (*Boltnd, error) {
 
 	return &Boltnd{
 		rpcServer: rpcserver,
+		cfg:       cfg,
 	}, nil
 }
 
@@ -75,6 +78,17 @@ func (b *Boltnd) Stop() error {
 	}
 
 	return nil
+}
+
+// requestShutdown calls our graceful shutdown closure, if supplied.
+func (b *Boltnd) requestShutdown() {
+	if b.cfg.RequestShutdown == nil {
+		log.Info("No graceful shutdown closure provided")
+		return
+	}
+
+	log.Info("Requesting graceful shutdown")
+	b.cfg.RequestShutdown()
 }
 
 // RegisterGrpcSubserver is a callback on the lnd.SubserverConfig struct that is

--- a/boltnd.go
+++ b/boltnd.go
@@ -39,7 +39,7 @@ func NewBoltnd(opts ...ConfigOption) (*Boltnd, error) {
 
 	setupLoggers(cfg)
 
-	rpcserver, err := rpcserver.NewServer(cfg.LndClientCfg)
+	rpcserver, err := rpcserver.NewServer()
 	if err != nil {
 		return nil, fmt.Errorf("could not create rpcserver: %v", err)
 	}

--- a/boltnd.go
+++ b/boltnd.go
@@ -41,7 +41,7 @@ func NewBoltnd(opts ...ConfigOption) (*Boltnd, error) {
 
 	rpcserver, err := rpcserver.NewServer(cfg.LndClientCfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not create rpcserver: %v", err)
 	}
 
 	return &Boltnd{
@@ -59,7 +59,7 @@ func (b *Boltnd) Start() error {
 	log.Info("Starting Boltnd")
 
 	if err := b.rpcServer.Start(); err != nil {
-		return err
+		return fmt.Errorf("error starting rpcserver: %v", err)
 	}
 
 	return nil
@@ -74,7 +74,7 @@ func (b *Boltnd) Stop() error {
 	log.Info("Stopping Boltnd")
 
 	if err := b.rpcServer.Stop(); err != nil {
-		return err
+		return fmt.Errorf("could not stop rpcserver: %v", err)
 	}
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -28,6 +28,10 @@ type Config struct {
 
 	// SetupLogger is used to register our loggers with a top level logger.
 	SetupLogger func(prefix string, register LogRegistration)
+
+	// RequestShutdown is an optional closure to request clean shutdown
+	// from the calling entity if the boltnd instance errors out.
+	RequestShutdown func()
 }
 
 // Validate ensures that we have all the required config values set.
@@ -119,6 +123,15 @@ func OptionLNDLogger(root *build.RotatingLogWriter,
 func OptionSetupLogger(setup func(string, LogRegistration)) ConfigOption {
 	return func(c *Config) error {
 		c.SetupLogger = setup
+		return nil
+	}
+}
+
+// OptionRequestShutdown provides a closure that will gracefully shutdown the
+// calling code if boltnd exits with an error.
+func OptionRequestShutdown(s func()) ConfigOption {
+	return func(c *Config) error {
+		c.RequestShutdown = s
 		return nil
 	}
 }

--- a/rpcserver/server.go
+++ b/rpcserver/server.go
@@ -17,8 +17,6 @@ type Server struct {
 	started int32 // to be used atomically
 	stopped int32 // to be used atomically
 
-	cfg *lndclient.LndServicesConfig
-
 	// lnd provides a connection to lnd's other grpc servers. Since we need
 	// to connect to the grpc servers, this can't be done while we're busy
 	// setting up ourselves as a sub-server. Consequently, this value will
@@ -29,10 +27,8 @@ type Server struct {
 }
 
 // NewServer creates an offers server.
-func NewServer(cfg *lndclient.LndServicesConfig) (*Server, error) {
-	return &Server{
-		cfg: cfg,
-	}, nil
+func NewServer() (*Server, error) {
+	return &Server{}, nil
 }
 
 // Start starts the offers server.
@@ -42,13 +38,6 @@ func (s *Server) Start() error {
 	}
 
 	log.Info("Starting rpc server")
-
-	// Setup our lnd grpc client.
-	var err error
-	s.lnd, err = lndclient.NewLndServices(s.cfg)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -61,11 +50,6 @@ func (s *Server) Stop() error {
 
 	log.Info("Stopping rpc server")
 	defer log.Info("Stopped rpc server")
-
-	// Shut down our lnd grpc client if it is present.
-	if s.lnd != nil {
-		s.lnd.Close()
-	}
 
 	return nil
 }


### PR DESCRIPTION
When we call `boltnd.Start` in LND's main package, we're calling this function before lnd itself has started. This means that we can't connect to lnd. We need to add backoff logic to give lnd a chance to boot up. This PR just removes LND while we don't need it. It also adds logging + a `RequestShutdown` config option so that `boltnd` can signal to lnd that it needs to shut down.