### PR TITLE
multi: add macaroons to boltnd

### DIFF
--- a/itest/setup.go
+++ b/itest/setup.go
@@ -39,10 +39,10 @@ func setupForBolt12(t *testing.T, net *lntest.NetworkHarness) *bolt12TestSetup {
 	require.NoError(t, err, "bob restart")
 
 	// Next, connect to each node's offers subserver.
-	aliceConn, err := net.Alice.ConnectRPCWithMacaroon(nil)
+	aliceConn, err := net.Alice.ConnectRPC(true)
 	require.NoError(t, err, "alice grpc conn")
 
-	bobConn, err := net.Bob.ConnectRPCWithMacaroon(nil)
+	bobConn, err := net.Bob.ConnectRPC(true)
 	require.NoError(t, err, "bob grpc conn")
 
 	return &bolt12TestSetup{

--- a/rpcserver/macaroons.go
+++ b/rpcserver/macaroons.go
@@ -1,0 +1,12 @@
+package rpcserver
+
+import "gopkg.in/macaroon-bakery.v2/bakery"
+
+// RPCServerPermissions is the set of macaroon permissions needed for each
+// api.
+var RPCServerPermissions = map[string][]bakery.Op{
+	"/offersrpc.Offers/SendOnionMessage": {{
+		Entity: "peers",
+		Action: "write",
+	}},
+}


### PR DESCRIPTION
When we register as a subserver with lnd and macaroons are enabled, we need to register our permissions with lnd. 