### PR TITLE
lnwire: properly decode onion message blob

### DIFF
--- a/lnwire/onion_message.go
+++ b/lnwire/onion_message.go
@@ -58,7 +58,7 @@ func (o *OnionMessage) Decode(r io.Reader, _ uint32) error {
 		return fmt.Errorf("decode onion len: %w", err)
 	}
 
-	o.OnionBlob = make([]byte, 0, onionLen)
+	o.OnionBlob = make([]byte, onionLen)
 	if err := lndwire.ReadElement(r, o.OnionBlob); err != nil {
 		return fmt.Errorf("read onion blob: %w", err)
 	}

--- a/lnwire/onion_message_test.go
+++ b/lnwire/onion_message_test.go
@@ -22,4 +22,5 @@ func TestOnionMessageEncode(t *testing.T) {
 	actual := &OnionMessage{}
 	err = actual.Decode(buf, 0)
 	require.NoError(t, err, "onion decode")
+	require.Equal(t, expected, actual, "message comparison")
 }


### PR DESCRIPTION
* Update test to properly cover encode/decode
* Fix allocation of `OnionBlob` in decode