### PR TITLE
rpcserver: add testing mock and send message unit test

### DIFF
--- a/rpcserver/impl_sendonionmessage_test.go
+++ b/rpcserver/impl_sendonionmessage_test.go
@@ -1,0 +1,101 @@
+package rpcserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/carlakc/boltnd/offersrpc"
+	"github.com/carlakc/boltnd/testutils"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestRPCSendOnionMessage tests the rpc mechanics around sending an onion
+// message. This function is primarily concerned with parsing, error handling
+// and response creation, so the actual send message functionality is mocked.
+func TestRPCSendOnionMessage(t *testing.T) {
+	pubkey := testutils.GetPubkeys(t, 1)[0]
+	pubkeyBytes := pubkey.SerializeCompressed()
+
+	vertex, err := route.NewVertexFromBytes(pubkeyBytes)
+	require.NoError(t, err, "pubkey")
+
+	tests := []struct {
+		name      string
+		setupMock func(*mock.Mock)
+		request   *offersrpc.SendOnionMessageRequest
+		success   bool
+		errCode   codes.Code
+	}{
+		{
+			name: "invalid pubkey",
+			request: &offersrpc.SendOnionMessageRequest{
+				Pubkey: []byte{1, 2, 3},
+			},
+			success: false,
+			errCode: codes.InvalidArgument,
+		},
+		{
+			name: "send message failed",
+			// Setup our mock to fail sending a message.
+			setupMock: func(m *mock.Mock) {
+				mockSendMessage(m, vertex, errors.New("mock"))
+			},
+			request: &offersrpc.SendOnionMessageRequest{
+				Pubkey: pubkeyBytes,
+			},
+			success: false,
+			errCode: codes.Internal,
+		},
+		{
+			name: "send message succeeds",
+			// Setup our mock to successfully send the message.
+			setupMock: func(m *mock.Mock) {
+				mockSendMessage(m, vertex, nil)
+			},
+			request: &offersrpc.SendOnionMessageRequest{
+				Pubkey: pubkeyBytes,
+			},
+			success: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			s := newServerTest(t)
+			s.start()
+			defer s.stop()
+
+			// Prime mock if required.
+			if testCase.setupMock != nil {
+				testCase.setupMock(s.offerMock.Mock)
+			}
+
+			// Send the test's request to the server.
+			_, err := s.server.SendOnionMessage(
+				context.Background(), testCase.request,
+			)
+			require.Equal(t, testCase.success, err == nil)
+
+			// If our test was a success, we don't need to test our
+			// error further.
+			if testCase.success {
+				return
+			}
+
+			// If we expect a failure, assert that it has the error
+			// code we want.
+			require.NotNil(t, err, "expected failure")
+
+			status, ok := status.FromError(err)
+			require.True(t, ok, "expected coded error")
+			require.Equal(t, status.Code(), testCase.errCode)
+		})
+	}
+}

--- a/rpcserver/testutils.go
+++ b/rpcserver/testutils.go
@@ -1,0 +1,85 @@
+package rpcserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/carlakc/boltnd/onionmsg"
+	"github.com/carlakc/boltnd/testutils"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type serverTest struct {
+	t         *testing.T
+	server    *Server
+	lnd       *testutils.MockLND
+	offerMock *offersMock
+}
+
+func newServerTest(t *testing.T) *serverTest {
+	serverTest := &serverTest{
+		t:         t,
+		lnd:       testutils.NewMockLnd(),
+		offerMock: newOffersMock(),
+	}
+
+	var err error
+	serverTest.server, err = NewServer(nil)
+	require.NoError(t, err, "new server")
+
+	// Override our onion messenger with a mock.
+	serverTest.server.onionMsgr = serverTest.offerMock
+
+	return serverTest
+}
+
+// start unblocks the server for our test, in lieu of calling the server's
+// actual start function.
+func (s *serverTest) start() {
+	// We don't use our actual start function, because that will fill in
+	// a real onion messenger. Instead, we just close our ready channel
+	// to unblock server requests.
+	close(s.server.ready)
+}
+
+// stop shuts down our server, asserting that mocks have been called as
+// expected.
+func (s *serverTest) stop() {
+	s.lnd.Mock.AssertExpectations(s.t)
+	s.offerMock.Mock.AssertExpectations(s.t)
+}
+
+// offersMock houses a mock for all the external interfaces that the rpcserver
+// required. This allows tests to focus on parsing, error handling and response
+// formatting.
+type offersMock struct {
+	*mock.Mock
+
+	// Embed the onion messenger interface so that all functionality is
+	// included.
+	onionmsg.OnionMessenger
+}
+
+func newOffersMock() *offersMock {
+	return &offersMock{
+		Mock: &mock.Mock{},
+	}
+}
+
+// SendMessage mocks sending a message.
+func (o *offersMock) SendMessage(ctx context.Context, peer route.Vertex) error {
+	args := o.Mock.MethodCalled("SendMessage", ctx, peer)
+	return args.Error(0)
+}
+
+// mockSendMessage primes our mock to return the error provided when we call
+// send message with the peer provided.
+func mockSendMessage(m *mock.Mock, peer route.Vertex, err error) {
+	m.On(
+		"SendMessage", mock.Anything, peer,
+	).Once().Return(
+		err,
+	)
+}


### PR DESCRIPTION
Increase coverage by adding tests to rpcserver.

Workaround note: the current unit tests don't call the `rpcServer`'s `Start` function because that'll create a new (not mocked) `OnionMessenger`. This is a problem with needing to provide a lnd node on start (and thus set onion messenger on start, not previously on creation where it can be mocked). This arch is ok for POC, but is an ugly pattern and should ideally be removed.