### PR TITLE
offers: add tlv merkle root calculation for signature verification

### DIFF
--- a/offers/merkle_tlv.go
+++ b/offers/merkle_tlv.go
@@ -1,0 +1,130 @@
+package offers
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+var (
+	// signatureFieldStart is the beginning of the inclusive tlv range that
+	// contains signatures.
+	signatureFieldStart tlv.Type = 240
+
+	// signatureFieldEnd is the end of the inclusive tlv range that contains
+	// signatures.
+	signatureFieldEnd tlv.Type = 1000
+
+	// TLVTag is the tag used for nodes containing TLV values.
+	TLVTag = []byte("LnLeaf")
+
+	// NonceTag is the tag used for nodes containing TLV nonces.
+	NonceTag = []byte("LnAll")
+)
+
+// tlvEncode is the function signature used to encode TLV records.
+type tlvEncode func(record tlv.Record, b [8]byte) ([]byte, error)
+
+// TLVLeaf represents a leaf in our offer merkle tree.
+type TLVLeaf struct {
+	// Tag is the tag to be used when hashing the value into a node.
+	Tag []byte
+
+	// Value is the value contained in the leaf.
+	Value []byte
+}
+
+// TaggedHash computes the tagged hash of a leaf, as defined by:
+// H(tag, msg) = sha256(sha256(tag) || sha256(tag) || msg)
+// TaggedHash = H("LnLeaf"/"LnAll" + all_tlvs , tlv )
+//
+// Note: the String() function on chainhash.Hash produces a hex-encoded byte
+// reversed hash (and the spec test vectors aren't reversed).
+func (t *TLVLeaf) TaggedHash() chainhash.Hash {
+	return *chainhash.TaggedHash(t.Tag, t.Value)
+}
+
+// CreateTLVLeaves creates a set of merkle leaves for a set of offer TLV
+// records, excluding signature fields. A tlvEncode function is passed in for
+// easy testing.
+func CreateTLVLeaves(records []tlv.Record, encode tlvEncode) ([]*TLVLeaf,
+	error) {
+
+	// First, sort the records in canonical order.
+	tlv.SortRecords(records)
+
+	var (
+		// Store each of our serialised TLVs to use for creating
+		// individual leaves.
+		encodedTLVs [][]byte
+
+		// Store the concatenation of all our TLV records separately
+		// to be used for nonce calculation.
+		allTLVs []byte
+
+		// Allocate for re-use encoding TLVs.
+		b [8]byte
+	)
+
+	for _, record := range records {
+		if isSignatureTLV(record) {
+			continue
+		}
+
+		tlvBytes, err := encode(record, b)
+		if err != nil {
+			return nil, fmt.Errorf("encode tlv: %v, %w",
+				record.Type(), err)
+		}
+
+		encodedTLVs = append(encodedTLVs, tlvBytes)
+		allTLVs = append(allTLVs, tlvBytes...)
+	}
+
+	// Each TLV record leaf is paired with a nonce leaf, so we allocate
+	// a slice 2x the number of our leaf records.
+	leaves := make([]*TLVLeaf, len(encodedTLVs)*2)
+
+	for i := 0; i < len(encodedTLVs); i++ {
+		tlv := encodedTLVs[i]
+
+		// We take up two elements in the leaf slice per iteration,
+		// so our index is 2x the record's index.
+		leafIndex := i * 2
+
+		// Our nonce leaf follows the tlv record in our leaf slice.
+		nonceIndex := leafIndex + 1
+
+		// Create the pair of leaves for this tlv.
+		leaves[leafIndex], leaves[nonceIndex] = createLeafPair(
+			tlv, allTLVs,
+		)
+	}
+
+	return leaves, nil
+}
+
+// createLeafPair creates a tlv and nonce pair of leaves for a TLV record.
+func createLeafPair(tlv, allTLVs []byte) (*TLVLeaf, *TLVLeaf) {
+	tlvLeaf := &TLVLeaf{
+		Tag:   TLVTag,
+		Value: tlv,
+	}
+
+	nonceLeaf := &TLVLeaf{
+		Tag:   append(NonceTag, allTLVs...),
+		Value: tlv,
+	}
+
+	return tlvLeaf, nonceLeaf
+}
+
+// isSignatureTLV returns a boolean indicating whether a TLV contains a
+// signature.
+func isSignatureTLV(record tlv.Record) bool {
+	tlvType := record.Type()
+
+	return tlvType >= signatureFieldStart &&
+		tlvType <= signatureFieldEnd
+}

--- a/offers/merkle_tlv.go
+++ b/offers/merkle_tlv.go
@@ -128,3 +128,27 @@ func isSignatureTLV(record tlv.Record) bool {
 	return tlvType >= signatureFieldStart &&
 		tlvType <= signatureFieldEnd
 }
+
+// encodeTLV serialized a record in our typical type / length / value format.
+func encodeTLV(record tlv.Record, b [8]byte) ([]byte, error) {
+	w := new(bytes.Buffer)
+
+	err := tlv.WriteVarInt(w, uint64(record.Type()), &b)
+	if err != nil {
+		return nil, fmt.Errorf("encode type: %w", err)
+	}
+
+	// Write the record’s length as a varint.
+	err = tlv.WriteVarInt(w, record.Size(), &b)
+	if err != nil {
+		return nil, fmt.Errorf("encode length: %w", err)
+	}
+
+	// Encode the current record’s value.
+	err = record.Encode(w)
+	if err != nil {
+		return nil, fmt.Errorf("encode value: %w", err)
+	}
+
+	return w.Bytes(), nil
+}

--- a/offers/merkle_tlv.go
+++ b/offers/merkle_tlv.go
@@ -97,6 +97,26 @@ func (t *TLVLeaf) TaggedHash() chainhash.Hash {
 	return *chainhash.TaggedHash(t.Tag, t.Value)
 }
 
+// CalculateRoot combines a set of branches into a merkle root.
+func CalculateRoot(branches []*TLVBranch) chainhash.Hash {
+	for len(branches) != 1 {
+		left, right := orderNodes(branches[0], branches[1])
+
+		newBranch := &TLVBranch{
+			left:  left,
+			right: right,
+		}
+
+		// Remove the individual branches from our set, and add our
+		// combined branch.
+		branches = branches[2:]
+		branches = append(branches, newBranch)
+	}
+
+	// We exit when we only have one branch left, this is our root.
+	return branches[0].TaggedHash()
+}
+
 // CreateTLVBranches creates a set of branches from an initial set of leaves.
 func CreateTLVBranches(leaves []*TLVLeaf) ([]*TLVBranch, error) {
 	if len(leaves)%2 != 0 {

--- a/offers/merkle_tlv_test.go
+++ b/offers/merkle_tlv_test.go
@@ -1,0 +1,141 @@
+package offers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTLVEncode is a mocked encoding function for TLV records used for testing.
+// It just writes the record's type for simplicity. This allows our mocked
+// record types to have nil encoders / decoders.
+func mockTLVEncode(record tlv.Record, b [8]byte) ([]byte, error) {
+	w := new(bytes.Buffer)
+
+	if err := tlv.WriteVarInt(w, uint64(record.Type()), &b); err != nil {
+		return nil, err
+	}
+
+	return w.Bytes(), nil
+}
+
+// TestCreateTLVLeaves tests creation of tlv and nonce leaves, and filtering out
+// of signature tlvs.
+func TestCreateTLVLeaves(t *testing.T) {
+	var (
+		// Create two non-sig records with an arbitrary type.
+		record1 = tlv.MakeStaticRecord(
+			10, nil, 0, nil, nil,
+		)
+
+		record2 = tlv.MakeStaticRecord(
+			20, nil, 0, nil, nil,
+		)
+
+		// Create a non-sig record that is _after_ the signature tlv
+		// type range.
+		record3 = tlv.MakeStaticRecord(
+			tlv.Type(signatureFieldEnd)+1, nil, 0, nil, nil,
+		)
+
+		// Create a sig record at the beginning of our range.
+		sig = tlv.MakeStaticRecord(
+			signatureFieldStart, nil, 0, nil, nil,
+		)
+
+		// Re-use for tlv encoding.
+		b [8]byte
+	)
+
+	record1Bytes, err := mockTLVEncode(record1, b)
+	require.NoError(t, err, "record 1 encode")
+
+	record2Bytes, err := mockTLVEncode(record2, b)
+	require.NoError(t, err, "record 2 encode")
+
+	record3Bytes, err := mockTLVEncode(record3, b)
+	require.NoError(t, err, "record 3 encode")
+
+	// Lazy combine all of our TLVs.
+	allBytes := append(record1Bytes, record2Bytes...)
+	allBytes = append(allBytes, record3Bytes...)
+
+	record1Leaf := &TLVLeaf{
+		Tag:   TLVTag,
+		Value: record1Bytes,
+	}
+
+	record1Nonce := &TLVLeaf{
+		Tag:   append(NonceTag, allBytes...),
+		Value: record1Bytes,
+	}
+
+	record2Leaf := &TLVLeaf{
+		Tag:   TLVTag,
+		Value: record2Bytes,
+	}
+
+	record2Nonce := &TLVLeaf{
+		Tag:   append(NonceTag, allBytes...),
+		Value: record2Bytes,
+	}
+
+	record3Leaf := &TLVLeaf{
+		Tag:   TLVTag,
+		Value: record3Bytes,
+	}
+
+	record3Nonce := &TLVLeaf{
+		Tag:   append(NonceTag, allBytes...),
+		Value: record3Bytes,
+	}
+
+	tests := []struct {
+		name     string
+		records  []tlv.Record
+		expected []*TLVLeaf
+	}{
+		{
+			name: "all records, out of order",
+			records: []tlv.Record{
+				record2, record1, record3,
+			},
+			expected: []*TLVLeaf{
+				record1Leaf, record1Nonce,
+				record2Leaf, record2Nonce,
+				record3Leaf, record3Nonce,
+			},
+		},
+		{
+			name: "signature field excluded",
+			records: []tlv.Record{
+				record1, sig,
+			},
+			expected: []*TLVLeaf{
+				// Our nonce leaf only has our own bytes
+				// because we have a single record.
+				record1Leaf, {
+					Tag: append(
+						NonceTag, record1Bytes...,
+					),
+					Value: record1Bytes,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := CreateTLVLeaves(
+				testCase.records, mockTLVEncode,
+			)
+			require.NoError(t, err, "create leaves")
+
+			require.Equal(t, testCase.expected, actual, "leaves")
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the merkle tree encoding for offer TLVs, used for signature verification. 

Note: the current top level function takes `[]tlv.Record`, before merge check that this input will be available to callers (ie, if we get an offer with unknown records, we'll probably only have the raw bytes available - see how lnd's stream construction deals with this)