### PR TITLE
offers: add records from parsed types for tree calculation

### DIFF
--- a/offers/merkle_tlv.go
+++ b/offers/merkle_tlv.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -275,4 +276,34 @@ func encodeTLV(record tlv.Record, b [8]byte) ([]byte, error) {
 	}
 
 	return w.Bytes(), nil
+}
+
+// recordsFromParsedTypes returns a set of tlv records from the set of parsed
+// types from a tlv stream. This function is used to produce records for tlv
+// types that we don't recognize (eg, odd records that are unknown to our code)
+// so that they can be included in merkle root calculation.
+func recordsFromParsedTypes(parsedTypes map[tlv.Type][]byte) []tlv.Record { // nolint: unused
+	records := make([]tlv.Record, 0, len(parsedTypes))
+
+	for tlvType, tlvBytes := range parsedTypes {
+		// Create a record that just writes whatever bytes we have for
+		// the TLV value. Any encoding specifics will be included in
+		// these bytes, because we've just read them straight out of the
+		// tlv stream.
+		encode := func(w io.Writer, _ interface{}, _ *[8]byte) error {
+			_, err := w.Write(tlvBytes)
+			return err
+		}
+
+		// Create a static record with encoding capabilities, we don't
+		// include a decode function because we don't need one to
+		// calculate our merkle root.
+		record := tlv.MakeStaticRecord(
+			tlvType, tlvBytes, uint64(len(tlvBytes)), encode, nil,
+		)
+
+		records = append(records, record)
+	}
+
+	return records
 }


### PR DESCRIPTION
When we decode an offer from another party, it's possible that it
contains odd TLVs that our code does not recognize. We need to include
these fields in our merkle root calculation, so this commit adds a
helper will will create tlv records that simply writes the bytes as
we originally read them out (in a tlv stream) for inclusion in root
calculation.