### PR TITLE
offers: move encoding to lnwire, add logging

### DIFF
--- a/boltnd.go
+++ b/boltnd.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/carlakc/boltnd/offers"
 	"github.com/carlakc/boltnd/offersrpc"
 	"github.com/carlakc/boltnd/onionmsg"
 	"github.com/carlakc/boltnd/rpcserver"
@@ -175,4 +176,5 @@ func setupLoggers(cfg *Config) {
 	cfg.SetupLogger(Subsystem, UseLogger)
 	cfg.SetupLogger(rpcserver.Subsystem, rpcserver.UseLogger)
 	cfg.SetupLogger(onionmsg.Subsystem, onionmsg.UseLogger)
+	cfg.SetupLogger(offers.Subsystem, offers.UseLogger)
 }

--- a/lnwire/bolt12_merkle.go
+++ b/lnwire/bolt12_merkle.go
@@ -1,4 +1,4 @@
-package offers
+package lnwire
 
 import (
 	"bytes"

--- a/lnwire/bolt12_merkle_test.go
+++ b/lnwire/bolt12_merkle_test.go
@@ -1,4 +1,4 @@
-package offers
+package lnwire
 
 import (
 	"bytes"

--- a/lnwire/bolt12_signature.go
+++ b/lnwire/bolt12_signature.go
@@ -1,0 +1,62 @@
+package lnwire
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+var (
+	// lightningTag is the top level tag used to tag signatures on offers.
+	lightningTag = []byte("lightning")
+
+	// offerTag is the message tag used to tag signatures on offers.
+	offerTag = []byte("offer")
+
+	// signatureTag is the field tag used to tag signatures (TLV type= 240)
+	// for offers.
+	signatureTag = []byte("signature")
+)
+
+// signatureDigest returns the tagged merkle root that is used for offer
+// signatures.
+func signatureDigest(messageTag, fieldTag []byte,
+	root chainhash.Hash) chainhash.Hash {
+
+	// The tag has the following format:
+	// lightning || message tag || field tag
+	tags := [][]byte{
+		lightningTag, messageTag, fieldTag,
+	}
+
+	// Create a tagged hash with the merkle root.
+	digest := chainhash.TaggedHash(
+		bytes.Join(tags, []byte{}), root[:],
+	)
+
+	return *digest
+}
+
+func validateSignature(signature [64]byte, nodeID *btcec.PublicKey,
+	digest []byte) error {
+
+	sig, err := schnorr.ParseSignature(signature[:])
+	if err != nil {
+		return fmt.Errorf("invalid signature: %v: %w",
+			hex.EncodeToString(signature[:]), err)
+	}
+
+	if !sig.Verify(digest, nodeID) {
+		return fmt.Errorf("%w: %v for: %v from: %v", ErrInvalidOfferSig,
+			hex.EncodeToString(signature[:]),
+			hex.EncodeToString(digest),
+			hex.EncodeToString(schnorr.SerializePubKey(nodeID)),
+		)
+	}
+
+	return nil
+}

--- a/lnwire/offer_test.go
+++ b/lnwire/offer_test.go
@@ -1,4 +1,4 @@
-package offers
+package lnwire
 
 import (
 	"errors"

--- a/lnwire/tu64.go
+++ b/lnwire/tu64.go
@@ -1,0 +1,41 @@
+package lnwire
+
+import (
+	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// encodeTU64 encodes a truncated uint64 tlv.
+//
+// Note: lnd doesn't have this functionality on its own yet (only in mpp encode)
+// so it is added here.
+func encodeTU64(w io.Writer, val interface{}, buf *[8]byte) error {
+	if v, ok := val.(*uint64); ok {
+		return tlv.ETUint64T(w, *v, buf)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "tu64")
+}
+
+// decodeTU64 decodes a truncated uint64 tlv.
+//
+// Note: lnd doesn't have this functionality on its own yet (only in mpp decode)
+// so it is added here.
+func decodeTU64(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
+	if v, ok := val.(*uint64); ok && 1 <= l && l <= 8 {
+		if err := tlv.DTUint64(r, v, buf, l); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "tu64", l, l)
+}
+
+func tu64Record(tlvType tlv.Type, value *uint64) tlv.Record {
+	return tlv.MakeDynamicRecord(tlvType, value, func() uint64 {
+		return tlv.SizeTUint64(*value)
+	}, encodeTU64, decodeTU64)
+}

--- a/offers/encoding.go
+++ b/offers/encoding.go
@@ -1,14 +1,26 @@
 package offers
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil/bech32"
+	"github.com/carlakc/boltnd/lnwire"
+)
+
+var (
+	// ErrInvalidOfferStr is returned when we fail to decode a bech32
+	// encoded offer string.
+	ErrInvalidOfferStr = errors.New("invalid offer string")
+
+	// ErrBadHRP is returned when an offer string has the wrong bech32
+	// human readable prefix.
+	ErrBadHRP = fmt.Errorf("incorrect bech32 hrp, should be: %v", offerHRP)
 )
 
 // DecodeOfferStr decodes a bech32 encoded offer string, returning our offer
 // type with the information contained in the offer.
-func DecodeOfferStr(offerStr string) (*Offer, error) {
+func DecodeOfferStr(offerStr string) (*lnwire.Offer, error) {
 	// First, strip any joining characters / spare whitespace from the
 	// offer.
 	cleanOffer, err := stripOffer(offerStr)
@@ -30,7 +42,7 @@ func DecodeOfferStr(offerStr string) (*Offer, error) {
 		return nil, fmt.Errorf("convert bits: %w", err)
 	}
 
-	offer, err := DecodeOffer(offerBytes)
+	offer, err := lnwire.DecodeOffer(offerBytes)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode offer: %w", err)
 	}

--- a/offers/log.go
+++ b/offers/log.go
@@ -1,0 +1,25 @@
+package offers
+
+import "github.com/btcsuite/btclog"
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "B12-OFR"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+// nolint: unused
+var log = btclog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/rpcserver/impl_decodeoffer.go
+++ b/rpcserver/impl_decodeoffer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/carlakc/boltnd/lnwire"
 	"github.com/carlakc/boltnd/offers"
 	"github.com/carlakc/boltnd/offersrpc"
 	"google.golang.org/grpc/codes"
@@ -54,7 +55,7 @@ func parseDecodeOfferRequest(req *offersrpc.DecodeOfferRequest) (string,
 
 // composeDecodeOfferResponse creates a DecodeOfferResponse from the internal
 // offer type.
-func composeDecodeOfferResponse(offer *offers.Offer) (
+func composeDecodeOfferResponse(offer *lnwire.Offer) (
 	*offersrpc.DecodeOfferResponse, error) {
 
 	rpcOffer := &offersrpc.Offer{


### PR DESCRIPTION
Some misc structural fixups: 
* Move offer encoding + merkle code to lnwire
* Add logger to offers subsystem