### PR TITLE
lnwire: add bolt 12 invoice and invoice request encoding

### DIFF
--- a/lnwire/bolt12_invoice.go
+++ b/lnwire/bolt12_invoice.go
@@ -158,7 +158,7 @@ func (i *Invoice) Validate() error {
 	// the offer.
 	if i.Signature != nil {
 		sigDigest := signatureDigest(
-			invoiceTag, invoiceRequestTag, i.MerkleRoot,
+			invoiceTag, signatureTag, i.MerkleRoot,
 		)
 
 		if err := validateSignature(

--- a/lnwire/bolt12_invoice.go
+++ b/lnwire/bolt12_invoice.go
@@ -1,0 +1,331 @@
+package lnwire
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	lndwire "github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// invOfferIDType is a record holding the offer ID that an invoice is
+	// associated with.
+	invOfferIDType tlv.Type = 4
+
+	// invAmountType is a record for the amount for an invoice.
+	invAmountType tlv.Type = 8
+
+	// invDescType is a record for a description for the invoice.
+	invDescType tlv.Type = 10
+
+	// invFeatType is a record containing the features required for the
+	// invoice.
+	invFeatType tlv.Type = 12
+
+	// invNodeIDType is a record for the node's public key.
+	invNodeIDType tlv.Type = 30
+
+	// invQuantityType is a record denoting the quantity that an invoice is
+	// for.
+	invQuantityType tlv.Type = 32
+
+	// invPayerKeyType is a record containing the paying party's "proof of
+	// payee" key.
+	invPayerKeyType tlv.Type = 38
+
+	// invPayerNoteType is a record for an optional payer note.
+	invPayerNoteType tlv.Type = 39
+
+	// invCreatedAtType is a record for the unix timestamp that the invoice
+	// was created at.
+	invCreatedAtType tlv.Type = 40
+
+	// invPaymentHashType is a record for the payment hash for the invoice.
+	invPaymentHashType tlv.Type = 42
+
+	// invRelativeExpiryType is a record for the relative expiry from the
+	// creation time, expressed in seconds.
+	invRelativeExpiryType tlv.Type = 44
+
+	// inCLTVType is a record for the minimum final cltv expiry of the
+	// invoice.
+	inCLTVType tlv.Type = 46
+
+	// invPayerInfoType is a record for arbitrary payer information.
+	invPayerInfoType tlv.Type = 50
+
+	// invSigType is a record for a signature over the invoice.
+	invSigType tlv.Type = 240
+)
+
+// Invoice represents a bolt 12 invoice.
+type Invoice struct {
+	// OfferID is the merkle root of the offer this invoice is associated
+	// with.
+	OfferID lntypes.Hash
+
+	// Amount is the amount that the invoice is for.
+	Amount lndwire.MilliSatoshi
+
+	// Description is an optional description of the invoice.
+	Description string
+
+	// Features is the set of features the invoice requires.
+	Features *lndwire.FeatureVector
+
+	// NodeID is the node ID for the recipient.
+	NodeID *btcec.PublicKey
+
+	// Quantity is an optional quantity of items for the invoice.
+	Quantity uint64
+
+	// PayerKey is the paying party's "proof of payee" key.
+	PayerKey *btcec.PublicKey
+
+	// PayerNote is an optional note from the paying party.
+	PayerNote string
+
+	// CreatedAt is the time the invoice was created.
+	CreatedAt time.Time
+
+	// PaymentHash is the payment hash for this invoice.
+	PaymentHash lntypes.Hash
+
+	// RelativeExpiry is the relative expiry in seconds from the invoice's
+	// created time.
+	RelativeExpiry time.Duration
+
+	// CLTVExpiry is the minimum final cltv expiry for the invoice.
+	CLTVExpiry uint64
+
+	// PayerInfo is an arbitrary piece of data set by the payer.
+	PayerInfo []byte
+
+	// Signature is a signature over the tlv merkle root of the invoice's
+	// fields.
+	Signature *[64]byte
+
+	// MerkleRoot is the merkle root of all the non-signature tlvs included
+	// in the invoice. This field isn't actually encoded in our tlv stream,
+	// but rather calculated from it.
+	MerkleRoot lntypes.Hash
+}
+
+// Compile time check that invoice implements the tlvTree interface.
+var _ tlvTree = (*Invoice)(nil)
+
+// records returns a set of tlv records for all the non-nil invoice fields.
+func (i *Invoice) records() ([]tlv.Record, error) {
+	var records []tlv.Record
+
+	if i.OfferID != lntypes.ZeroHash {
+		var offerID [32]byte
+		copy(offerID[:], i.OfferID[:])
+
+		record := tlv.MakePrimitiveRecord(invOfferIDType, &offerID)
+		records = append(records, record)
+	}
+
+	if i.Amount != 0 {
+		amount := uint64(i.Amount)
+
+		record := tlv.MakePrimitiveRecord(invAmountType, &amount)
+		records = append(records, record)
+	}
+
+	if i.Description != "" {
+		description := []byte(i.Description)
+
+		record := tlv.MakePrimitiveRecord(
+			invDescType, &description,
+		)
+		records = append(records, record)
+	}
+
+	featuresRecord, err := encodeFetauresRecord(invFeatType, i.Features)
+	if err != nil {
+		return nil, err
+	}
+
+	if featuresRecord != nil {
+		records = append(records, *featuresRecord)
+	}
+
+	if i.NodeID != nil {
+		record := tlv.MakePrimitiveRecord(invNodeIDType, &i.NodeID)
+		records = append(records, record)
+	}
+
+	if i.Quantity != 0 {
+		record := tlv.MakePrimitiveRecord(invQuantityType, &i.Quantity)
+		records = append(records, record)
+	}
+
+	if i.PayerKey != nil {
+		record := tlv.MakePrimitiveRecord(invPayerKeyType, &i.PayerKey)
+		records = append(records, record)
+	}
+
+	if i.PayerNote != "" {
+		note := []byte(i.PayerNote)
+
+		record := tlv.MakePrimitiveRecord(invPayerNoteType, &note)
+		records = append(records, record)
+	}
+
+	if !i.CreatedAt.IsZero() {
+		created := uint64(i.CreatedAt.Unix())
+
+		record := tlv.MakePrimitiveRecord(invCreatedAtType, &created)
+		records = append(records, record)
+	}
+
+	if i.PaymentHash != lntypes.ZeroHash {
+		var payHash [32]byte
+		copy(payHash[:], i.PaymentHash[:])
+
+		record := tlv.MakePrimitiveRecord(invPaymentHashType, &payHash)
+		records = append(records, record)
+	}
+
+	if i.RelativeExpiry != 0 {
+		expiry := uint64(i.RelativeExpiry.Seconds())
+
+		record := tlv.MakePrimitiveRecord(invRelativeExpiryType, &expiry)
+		records = append(records, record)
+	}
+
+	if i.CLTVExpiry != 0 {
+		record := tlv.MakePrimitiveRecord(inCLTVType, &i.CLTVExpiry)
+		records = append(records, record)
+	}
+
+	if len(i.PayerInfo) != 0 {
+		record := tlv.MakePrimitiveRecord(invPayerInfoType, &i.PayerInfo)
+		records = append(records, record)
+	}
+
+	if i.Signature != nil {
+		signature := *i.Signature
+
+		record := tlv.MakePrimitiveRecord(invSigType, &signature)
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+// EncodeInvoice encodes a bolt12 invoice as a tlv stream.
+func EncodeInvoice(i *Invoice) ([]byte, error) {
+	records, err := i.records()
+	if err != nil {
+		return nil, fmt.Errorf("%w: invoice records", err)
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, fmt.Errorf("new stream: %w", err)
+	}
+
+	b := new(bytes.Buffer)
+	if err := stream.Encode(b); err != nil {
+		return nil, fmt.Errorf("encode stream: %w", err)
+	}
+
+	return b.Bytes(), nil
+}
+
+// DecodeInvoice decodes a bolt12 invoice tlv stream.
+func DecodeInvoice(b []byte) (*Invoice, error) {
+	var (
+		i                                = &Invoice{}
+		offerID, payHash                 [32]byte
+		amount                           uint64
+		features, description, payerNote []byte
+		createdAt                        uint64
+		relativeExpiry                   uint64
+		signature                        [64]byte
+	)
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(invOfferIDType, &offerID),
+		tlv.MakePrimitiveRecord(invAmountType, &amount),
+		tlv.MakePrimitiveRecord(invDescType, &description),
+		tlv.MakePrimitiveRecord(invFeatType, &features),
+		tlv.MakePrimitiveRecord(invNodeIDType, &i.NodeID),
+		tlv.MakePrimitiveRecord(invQuantityType, &i.Quantity),
+		tlv.MakePrimitiveRecord(invPayerKeyType, &i.PayerKey),
+		tlv.MakePrimitiveRecord(invPayerNoteType, &payerNote),
+		tlv.MakePrimitiveRecord(invCreatedAtType, &createdAt),
+		tlv.MakePrimitiveRecord(invPaymentHashType, &payHash),
+		tlv.MakePrimitiveRecord(invRelativeExpiryType, &relativeExpiry),
+		tlv.MakePrimitiveRecord(inCLTVType, &i.CLTVExpiry),
+		tlv.MakePrimitiveRecord(invPayerInfoType, &i.PayerInfo),
+		tlv.MakePrimitiveRecord(invSigType, &signature),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, fmt.Errorf("new stream: %w", err)
+	}
+
+	r := bytes.NewReader(b)
+	tlvMap, err := stream.DecodeWithParsedTypes(r)
+	if err != nil {
+		return nil, fmt.Errorf("decode stream: %w", err)
+	}
+
+	if _, ok := tlvMap[invOfferIDType]; ok {
+		i.OfferID, err = lntypes.MakeHash(offerID[:])
+		if err != nil {
+			return nil, fmt.Errorf("offer id: %w", err)
+		}
+	}
+
+	if _, ok := tlvMap[invAmountType]; ok {
+		i.Amount = lndwire.MilliSatoshi(amount)
+	}
+
+	_, found := tlvMap[invFeatType]
+	i.Features, err = decodeFeaturesRecord(features, found)
+	if err != nil {
+		return nil, fmt.Errorf("features decode: %w", err)
+	}
+
+	if _, ok := tlvMap[invDescType]; ok {
+		i.Description = string(description)
+	}
+
+	if _, ok := tlvMap[invPayerNoteType]; ok {
+		i.PayerNote = string(payerNote)
+	}
+
+	if _, ok := tlvMap[invCreatedAtType]; ok {
+		i.CreatedAt = time.Unix(int64(createdAt), 0)
+	}
+
+	if _, ok := tlvMap[invPaymentHashType]; ok {
+		i.PaymentHash, err = lntypes.MakeHash(payHash[:])
+		if err != nil {
+			return nil, fmt.Errorf("pay hash: %w", err)
+		}
+	}
+
+	if _, ok := tlvMap[invRelativeExpiryType]; ok {
+		i.RelativeExpiry = time.Second * time.Duration(relativeExpiry)
+	}
+
+	if _, ok := tlvMap[invSigType]; ok {
+		i.Signature = &signature
+	}
+
+	i.MerkleRoot, err = decodeMerkleRoot(i, tlvMap)
+	if err != nil {
+		return nil, fmt.Errorf("merkle root: %w", err)
+	}
+
+	return i, nil
+}

--- a/lnwire/bolt12_invoice.go
+++ b/lnwire/bolt12_invoice.go
@@ -158,7 +158,7 @@ func (i *Invoice) Validate() error {
 	// the offer.
 	if i.Signature != nil {
 		sigDigest := signatureDigest(
-			invoiceTag, signatureTag, i.MerkleRoot,
+			invoiceTag, invoiceRequestTag, i.MerkleRoot,
 		)
 
 		if err := validateSignature(

--- a/lnwire/bolt12_invoice_request.go
+++ b/lnwire/bolt12_invoice_request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	lndwire "github.com/lightningnetwork/lnd/lnwire"
@@ -174,6 +175,12 @@ func NewInvoiceRequest(offer *Offer, amount lnwire.MilliSatoshi,
 	}
 
 	return request, nil
+}
+
+// SignatureDigest returns the tagged digest that is signed for invoice
+// requests.
+func (i *InvoiceRequest) SignatureDigest() chainhash.Hash {
+	return signatureDigest(invoiceRequestTag, signatureTag, i.MerkleRoot)
 }
 
 // Validate performs validation on an invoice request as described in the

--- a/lnwire/bolt12_invoice_request.go
+++ b/lnwire/bolt12_invoice_request.go
@@ -1,0 +1,235 @@
+package lnwire
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	lndwire "github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// invReqOfferIDType is a record containing the associated offer ID.
+	invReqOfferIDType tlv.Type = 4
+
+	// invReqAmountType is a record containing the invoice amount
+	// requested.
+	invReqAmountType tlv.Type = 8
+
+	// invReqFeaturesType is a record containing the feature vector for
+	// the request.
+	invReqFeaturesType tlv.Type = 12
+
+	// invReqQuantityType is a record for the quantity requested.
+	invReqQuantityType tlv.Type = 32
+
+	// invReqPayerKeyType is a record for the "proof-of-payer" key provided
+	// by the sender.
+	invReqPayerKeyType tlv.Type = 38
+
+	// invReqPayerNoteType is a record for a note from the sender.
+	invReqPayerNoteType tlv.Type = 39
+
+	// invReqPayerInfoType is a record for arbitrary information from the
+	// sender.
+	invReqPayerInfoType tlv.Type = 50
+
+	// invReqSignatureType is a record for the signature of the request's
+	// merkle root.
+	invReqSignatureType tlv.Type = 240
+)
+
+// InvoiceRequest represents a bolt 12 request for an invoice.
+type InvoiceRequest struct {
+	// OfferID is the merkle root of the offer this request is associated
+	// with.
+	OfferID lntypes.Hash
+
+	// Amount is the invoice amount that the request is for.
+	Amount lndwire.MilliSatoshi
+
+	// Features is the set of features required for the invoice.
+	Features *lndwire.FeatureVector
+
+	// Quantity is the number of items that the invoice is for.
+	Quantity uint64
+
+	// PayerKey is a proof-of-payee key for the sender.
+	PayerKey *btcec.PublicKey
+
+	// PayerNote is a note from the sender.
+	PayerNote string
+
+	// PayerInfo is arbitrary information included by the sender.
+	PayerInfo []byte
+
+	// Signature is an optional signature on the tlv merkle root of the
+	// request.
+	Signature *[64]byte
+
+	// MerkleRoot is the merkle root of all the non-signature tlvs included
+	// in the invoice request. This field isn't actually encoded in our
+	// tlv stream, but rather calculated from it.
+	MerkleRoot lntypes.Hash
+}
+
+// Compile time check that invoice request implements the tlv tree interface.
+var _ tlvTree = (*InvoiceRequest)(nil)
+
+// records returns a set of records for all the non-nil fields in an invoice
+// request.
+func (i *InvoiceRequest) records() ([]tlv.Record, error) {
+	var records []tlv.Record
+
+	if i.OfferID != lntypes.ZeroHash {
+		var offerID [32]byte
+		copy(offerID[:], i.OfferID[:])
+
+		record := tlv.MakePrimitiveRecord(invReqOfferIDType, &offerID)
+		records = append(records, record)
+	}
+
+	if i.Amount != 0 {
+		amount := uint64(i.Amount)
+
+		record := tlv.MakePrimitiveRecord(invReqAmountType, &amount)
+		records = append(records, record)
+	}
+
+	featuresRecord, err := encodeFetauresRecord(
+		invReqFeaturesType, i.Features,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("encode features: %w", err)
+	}
+
+	if featuresRecord != nil {
+		records = append(records, *featuresRecord)
+	}
+
+	if i.Quantity != 0 {
+		record := tlv.MakePrimitiveRecord(
+			invReqQuantityType, &i.Quantity,
+		)
+		records = append(records, record)
+	}
+
+	if i.PayerKey != nil {
+		record := tlv.MakePrimitiveRecord(
+			invReqPayerKeyType, &i.PayerKey,
+		)
+		records = append(records, record)
+	}
+
+	if i.PayerNote != "" {
+		note := []byte(i.PayerNote)
+
+		record := tlv.MakePrimitiveRecord(invReqPayerNoteType, &note)
+		records = append(records, record)
+	}
+
+	if len(i.PayerInfo) != 0 {
+		record := tlv.MakePrimitiveRecord(
+			invReqPayerInfoType, &i.PayerInfo,
+		)
+		records = append(records, record)
+	}
+
+	if i.Signature != nil {
+		signature := *i.Signature
+
+		record := tlv.MakePrimitiveRecord(
+			invReqSignatureType, &signature,
+		)
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+// EncodeInvoiceRequest encodes a bolt12 invoice request as a tlv stream.
+func EncodeInvoiceRequest(i *InvoiceRequest) ([]byte, error) {
+	records, err := i.records()
+	if err != nil {
+		return nil, fmt.Errorf("%w: invoice request records", err)
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, fmt.Errorf("new stream: %w", err)
+	}
+
+	b := new(bytes.Buffer)
+	if err := stream.Encode(b); err != nil {
+		return nil, fmt.Errorf("encode stream: %w", err)
+	}
+
+	return b.Bytes(), nil
+}
+
+// DecodeInvoiceRequest decodes a bolt12 invoice request tlv stream.
+func DecodeInvoiceRequest(b []byte) (*InvoiceRequest, error) {
+	var (
+		i                   = &InvoiceRequest{}
+		offerID             [32]byte
+		amount              uint64
+		features, payerNote []byte
+		signature           [64]byte
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(invReqOfferIDType, &offerID),
+		tlv.MakePrimitiveRecord(invReqAmountType, &amount),
+		tlv.MakePrimitiveRecord(invReqFeaturesType, &features),
+		tlv.MakePrimitiveRecord(invReqQuantityType, &i.Quantity),
+		tlv.MakePrimitiveRecord(invReqPayerKeyType, &i.PayerKey),
+		tlv.MakePrimitiveRecord(invReqPayerNoteType, &payerNote),
+		tlv.MakePrimitiveRecord(invReqPayerInfoType, &i.PayerInfo),
+		tlv.MakePrimitiveRecord(invReqSignatureType, &signature),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, fmt.Errorf("new stream: %w", err)
+	}
+
+	r := bytes.NewReader(b)
+	tlvMap, err := stream.DecodeWithParsedTypes(r)
+	if err != nil {
+		return nil, fmt.Errorf("decode stream: %w", err)
+	}
+
+	if _, ok := tlvMap[invReqOfferIDType]; ok {
+		i.OfferID, err = lntypes.MakeHash(offerID[:])
+		if err != nil {
+			return nil, fmt.Errorf("offer id: %w", err)
+		}
+	}
+
+	if _, ok := tlvMap[invReqAmountType]; ok {
+		i.Amount = lndwire.MilliSatoshi(amount)
+	}
+
+	_, found := tlvMap[invReqFeaturesType]
+	i.Features, err = decodeFeaturesRecord(features, found)
+	if err != nil {
+		return nil, fmt.Errorf("decode features: %w", err)
+	}
+
+	if _, ok := tlvMap[invReqPayerNoteType]; ok {
+		i.PayerNote = string(payerNote)
+	}
+
+	if _, ok := tlvMap[invReqSignatureType]; ok {
+		i.Signature = &signature
+	}
+
+	i.MerkleRoot, err = decodeMerkleRoot(i, tlvMap)
+	if err != nil {
+		return nil, fmt.Errorf("merkle root: %w", err)
+	}
+
+	return i, nil
+}

--- a/lnwire/bolt12_invoice_request_test.go
+++ b/lnwire/bolt12_invoice_request_test.go
@@ -1,0 +1,140 @@
+package lnwire
+
+import (
+	"testing"
+
+	"github.com/carlakc/boltnd/testutils"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInvoiceRequestEncoding tests encoding and decoding of bolt 12 invoice
+// requests. Test cases generally contain a single field per case to implicitly
+// test the case where a field is not included.
+func TestInvoiceRequestEncoding(t *testing.T) {
+	var (
+		pubkey = testutils.GetPubkeys(t, 1)[0]
+
+		hash lntypes.Hash
+
+		sig [64]byte
+	)
+
+	copy(hash[:], []byte{1, 2, 3})
+	copy(sig[:], []byte{4, 5, 6})
+
+	tests := []struct {
+		name    string
+		encoded *InvoiceRequest
+	}{
+		{
+			name: "offer id",
+			encoded: &InvoiceRequest{
+				OfferID: hash,
+			},
+		},
+		{
+			name: "amount",
+			encoded: &InvoiceRequest{
+				Amount: lnwire.MilliSatoshi(1),
+			},
+		},
+		{
+			name: "features - empty",
+			encoded: &InvoiceRequest{
+				// Include a non-empty record so that our merkle
+				// tree can be calculated on decode.
+				PayerKey: pubkey,
+				Features: lnwire.NewFeatureVector(
+					lnwire.NewRawFeatureVector(),
+					lnwire.Features,
+				),
+			},
+		},
+		{
+			name: "features - populated",
+			encoded: &InvoiceRequest{
+				Features: lnwire.NewFeatureVector(
+					lnwire.NewRawFeatureVector(
+						lnwire.AMPOptional,
+					),
+					lnwire.Features,
+				),
+			},
+		},
+		{
+			name: "quantity",
+			encoded: &InvoiceRequest{
+				Quantity: 3,
+			},
+		},
+		{
+			name: "payer key",
+			encoded: &InvoiceRequest{
+				PayerKey: pubkey,
+			},
+		},
+		{
+			name: "payer note",
+			encoded: &InvoiceRequest{
+				PayerNote: "note",
+			},
+		},
+		{
+			name: "payer info",
+			encoded: &InvoiceRequest{
+				PayerInfo: []byte{1, 2, 3},
+			},
+		},
+		{
+			name: "signature",
+			encoded: &InvoiceRequest{
+				// Include a non-sig record so that our merkle
+				// tree can be calculated on decode.
+				PayerKey:  pubkey,
+				Signature: &sig,
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			// Calculate the merkle root for the invoice request
+			// we're testing (rather than needing to pre-calculate
+			// it for each test case), so that we can use
+			// require.Equal to compare it to the decoded invoice
+			// (which has its merkle root calculated on decode).
+			records, err := testCase.encoded.records()
+			require.NoError(t, err, "records")
+
+			testCase.encoded.MerkleRoot, err = MerkleRoot(records)
+			require.NoError(t, err, "merkle root")
+
+			encodedBytes, err := EncodeInvoiceRequest(
+				testCase.encoded,
+			)
+			require.NoError(t, err, "encode")
+
+			decoded, err := DecodeInvoiceRequest(encodedBytes)
+			require.NoError(t, err, "decode")
+
+			// Our decoding creates an empty feature vector if no
+			// features TLV is present so that we can use the
+			// non-nil vector. If our test didn't set any features,
+			// fill in an empty feature vector so that we can use
+			// require.Equal for the encoded/decoded values.
+			if testCase.encoded.Features == nil {
+				testCase.encoded.Features =
+					lnwire.NewFeatureVector(
+						lnwire.NewRawFeatureVector(),
+						lnwire.Features,
+					)
+			}
+
+			require.Equal(t, testCase.encoded, decoded)
+		})
+	}
+}

--- a/lnwire/bolt12_invoice_test.go
+++ b/lnwire/bolt12_invoice_test.go
@@ -1,0 +1,177 @@
+package lnwire
+
+import (
+	"testing"
+	"time"
+
+	"github.com/carlakc/boltnd/testutils"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInvoiceEncoding tests encoding and decoding of bolt 12 invoices. Test
+// cases generally contain a single field per case to implicitly test the case
+// where a field is not included.
+func TestInvoiceEncoding(t *testing.T) {
+	var (
+		pubkey = testutils.GetPubkeys(t, 1)[0]
+
+		hash lntypes.Hash
+
+		sig [64]byte
+	)
+
+	copy(hash[:], []byte{1, 2, 3})
+	copy(sig[:], []byte{4, 5, 6})
+
+	tests := []struct {
+		name    string
+		encoded *Invoice
+	}{
+		{
+			name: "offer id",
+			encoded: &Invoice{
+				OfferID: hash,
+			},
+		},
+		{
+			name: "amount",
+			encoded: &Invoice{
+				Amount: lnwire.MilliSatoshi(1),
+			},
+		},
+		{
+			name: "description",
+			encoded: &Invoice{
+				Description: "inv description",
+			},
+		},
+		{
+			name: "features - empty",
+			encoded: &Invoice{
+				// Include a non-empty field so that our merkle
+				// tree can be calculated.
+				Description: "inv description",
+				Features: lnwire.NewFeatureVector(
+					lnwire.NewRawFeatureVector(),
+					lnwire.Features,
+				),
+			},
+		},
+		{
+			name: "features - populated",
+			encoded: &Invoice{
+				Features: lnwire.NewFeatureVector(
+					lnwire.NewRawFeatureVector(
+						lnwire.AMPOptional,
+					),
+					lnwire.Features,
+				),
+			},
+		},
+		{
+			name: "node id",
+			encoded: &Invoice{
+				NodeID: pubkey,
+			},
+		},
+		{
+			name: "quantity",
+			encoded: &Invoice{
+				Quantity: 3,
+			},
+		},
+		{
+			name: "payer key",
+			encoded: &Invoice{
+				PayerKey: pubkey,
+			},
+		},
+		{
+			name: "payer note",
+			encoded: &Invoice{
+				PayerNote: "note",
+			},
+		},
+		{
+			name: "created at",
+			encoded: &Invoice{
+				CreatedAt: time.Date(
+					2022, 01, 01, 0, 0, 0, 0, time.Local,
+				),
+			},
+		},
+		{
+			name: "payment hash",
+			encoded: &Invoice{
+				PaymentHash: hash,
+			},
+		},
+		{
+			name: "relative expiry",
+			encoded: &Invoice{
+				RelativeExpiry: time.Second * 20,
+			},
+		},
+		{
+			name: "cltv expiry",
+			encoded: &Invoice{
+				CLTVExpiry: 10,
+			},
+		},
+		{
+			name: "payer info",
+			encoded: &Invoice{
+				PayerInfo: []byte{1, 2, 3},
+			},
+		},
+		{
+			name: "signature",
+			encoded: &Invoice{
+				// Include a non-sig record so that our merkle
+				// tree can be calculated on decode.
+				PayerKey:  pubkey,
+				Signature: &sig,
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			// Calculate the merkle root for the invoice we're
+			// testing (rather than needing to pre-calculate it
+			// for each test case), so that we can use require.Equal
+			// to compare it to the decoded invoice (which has its
+			// merkle root calculated on decode).
+			records, err := testCase.encoded.records()
+			require.NoError(t, err, "records")
+
+			testCase.encoded.MerkleRoot, err = MerkleRoot(records)
+			require.NoError(t, err, "merkle root")
+
+			encodedBytes, err := EncodeInvoice(testCase.encoded)
+			require.NoError(t, err, "encode")
+
+			decoded, err := DecodeInvoice(encodedBytes)
+			require.NoError(t, err, "decode")
+
+			// Our decoding creates an empty feature vector if no
+			// features TLV is present so that we can use the
+			// non-nil vector. If our test didn't set any features,
+			// fill in an empty feature vector so that we can use
+			// require.Equal for the encoded/decoded values.
+			if testCase.encoded.Features == nil {
+				testCase.encoded.Features =
+					lnwire.NewFeatureVector(
+						lnwire.NewRawFeatureVector(),
+						lnwire.Features,
+					)
+			}
+
+			require.Equal(t, testCase.encoded, decoded)
+		})
+	}
+}

--- a/lnwire/bolt12_merkle.go
+++ b/lnwire/bolt12_merkle.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -103,23 +104,25 @@ func (t *TLVLeaf) TaggedHash() chainhash.Hash {
 }
 
 // MerkleRoot computes a merkle tree for the set of offer tlv records provided.
-func MerkleRoot(records []tlv.Record) (*chainhash.Hash, error) {
+func MerkleRoot(records []tlv.Record) (lntypes.Hash, error) {
 	leaves, err := CreateTLVLeaves(records, encodeTLV)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v records", err, len(records))
+		return lntypes.ZeroHash, fmt.Errorf("%w: %v records", err,
+			len(records))
 	}
 
 	if len(leaves) == 0 {
-		return nil, ErrNoTLVs
+		return lntypes.ZeroHash, ErrNoTLVs
 	}
 
 	branches, err := CreateTLVBranches(leaves)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v leaves", err, len(leaves))
+		return lntypes.ZeroHash, fmt.Errorf("%w: %v leaves", err,
+			len(leaves))
 	}
 
 	hash := CalculateRoot(branches)
-	return &hash, nil
+	return lntypes.MakeHash(hash[:])
 }
 
 // CalculateRoot combines a set of branches into a merkle root.

--- a/lnwire/bolt12_shared.go
+++ b/lnwire/bolt12_shared.go
@@ -1,0 +1,53 @@
+package lnwire
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// encodeFetauresRecord creates a tlv record with the type provided, encoding
+// the feature vector provided as a byte vector. If the vector provided is nil
+// or empty the record returned will be nil.
+func encodeFetauresRecord(recordType tlv.Type,
+	features *lnwire.FeatureVector) (*tlv.Record, error) {
+
+	if features == nil {
+		return nil, nil
+	}
+
+	if features.IsEmpty() {
+		return nil, nil
+	}
+
+	w := new(bytes.Buffer)
+
+	if err := features.Encode(w); err != nil {
+		return nil, fmt.Errorf("encode features: %w", err)
+	}
+
+	featureBytes := w.Bytes()
+
+	record := tlv.MakePrimitiveRecord(recordType, &featureBytes)
+	return &record, nil
+}
+
+// decodeFeaturesRecord decodes the features record provided. If it is not
+// present, an empty feature vector will be returned for easy use.
+func decodeFeaturesRecord(decodedFeatures []byte,
+	found bool) (*lnwire.FeatureVector, error) {
+
+	// Create an empty raw feature vector.
+	rawFeatures := lnwire.NewRawFeatureVector()
+
+	// If we decoded a value for our feature vector, decode it.
+	if found {
+		err := rawFeatures.Decode(bytes.NewReader(decodedFeatures))
+		if err != nil {
+			return nil, fmt.Errorf("raw features decode: %w", err)
+		}
+	}
+	return lnwire.NewFeatureVector(rawFeatures, lnwire.Features), nil
+}

--- a/lnwire/bolt12_signature.go
+++ b/lnwire/bolt12_signature.go
@@ -3,6 +3,7 @@ package lnwire
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -21,6 +22,10 @@ var (
 	// signatureTag is the field tag used to tag signatures (TLV type= 240)
 	// for offers.
 	signatureTag = []byte("signature")
+
+	// ErrInvalidSig is returned when the signature tlv value is
+	// invalid.
+	ErrInvalidSig = errors.New("invalid signature")
 )
 
 // signatureDigest returns the tagged merkle root that is used for offer
@@ -52,7 +57,7 @@ func validateSignature(signature [64]byte, nodeID *btcec.PublicKey,
 	}
 
 	if !sig.Verify(digest, nodeID) {
-		return fmt.Errorf("%w: %v for: %v from: %v", ErrInvalidOfferSig,
+		return fmt.Errorf("%w: %v for: %v from: %v", ErrInvalidSig,
 			hex.EncodeToString(signature[:]),
 			hex.EncodeToString(digest),
 			hex.EncodeToString(schnorr.SerializePubKey(nodeID)),

--- a/lnwire/bolt12_signature.go
+++ b/lnwire/bolt12_signature.go
@@ -22,6 +22,10 @@ var (
 	// invoiceTag is the message tag used to tag signatures on invoices.
 	invoiceTag = []byte("invoice")
 
+	// invoiceRequestTag is the message tag used to tag signatures on
+	// invoice requests.
+	invoiceRequestTag = []byte("invoicerequest")
+
 	// signatureTag is the field tag used to tag signatures (TLV type= 240)
 	// for offers.
 	signatureTag = []byte("signature")

--- a/lnwire/bolt12_signature.go
+++ b/lnwire/bolt12_signature.go
@@ -19,6 +19,9 @@ var (
 	// offerTag is the message tag used to tag signatures on offers.
 	offerTag = []byte("offer")
 
+	// invoiceTag is the message tag used to tag signatures on invoices.
+	invoiceTag = []byte("invoice")
+
 	// signatureTag is the field tag used to tag signatures (TLV type= 240)
 	// for offers.
 	signatureTag = []byte("signature")

--- a/lnwire/bolt12_signature.go
+++ b/lnwire/bolt12_signature.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/lntypes"
 )
 
 var (
@@ -25,7 +26,7 @@ var (
 // signatureDigest returns the tagged merkle root that is used for offer
 // signatures.
 func signatureDigest(messageTag, fieldTag []byte,
-	root chainhash.Hash) chainhash.Hash {
+	root lntypes.Hash) chainhash.Hash {
 
 	// The tag has the following format:
 	// lightning || message tag || field tag

--- a/lnwire/offer.go
+++ b/lnwire/offer.go
@@ -58,10 +58,6 @@ var (
 	// ErrDescriptionRequried is returned when an offer is invalid because
 	//  does not contain a description.
 	ErrDescriptionRequried = errors.New("offer description required")
-
-	// ErrInvalidOfferSig is returned when the signature for an offer is
-	// invalid for the merkle root we have calculated.
-	ErrInvalidOfferSig = errors.New("invalid offer signature")
 )
 
 // Offer represents a bolt 12 offer.

--- a/lnwire/offer_test.go
+++ b/lnwire/offer_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/carlakc/boltnd/testutils"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
@@ -123,7 +123,7 @@ func TestOfferEncoding(t *testing.T) {
 			// We also clear our merkle root value which is
 			// calculated when we decode the offer tlv stream, we're
 			// not testing this calculation here.
-			decoded.MerkleRoot = chainhash.Hash{}
+			decoded.MerkleRoot = lntypes.ZeroHash
 
 			require.Equal(t, testCase.offer, decoded)
 		})
@@ -153,7 +153,7 @@ func TestDecodedMerkleRoot(t *testing.T) {
 	decodedOffer, err := DecodeOffer(offerBytes)
 	require.NoError(t, err, "decode")
 
-	require.Equal(t, *merkleRoot, decodedOffer.MerkleRoot)
+	require.Equal(t, merkleRoot, decodedOffer.MerkleRoot)
 }
 
 // TestOfferValidation tests validation of offers.
@@ -164,11 +164,11 @@ func TestOfferValidation(t *testing.T) {
 
 	// Create a mock merkle root and sign it.
 	rootBytes := [32]byte{1, 2, 3}
-	root, err := chainhash.NewHash(rootBytes[:])
+	root, err := lntypes.MakeHash(rootBytes[:])
 	require.NoError(t, err, "merkle root")
 
 	digest := signatureDigest(
-		offerTag, signatureTag, *root,
+		offerTag, signatureTag, root,
 	)
 
 	sig, err := schnorr.Sign(nodePrivKey, digest[:])
@@ -182,7 +182,7 @@ func TestOfferValidation(t *testing.T) {
 	// Create another merkle root that won't match our signature to test
 	// bad sigs.
 	badRootBytes := [32]byte{1, 2, 3, 4}
-	badRoot, err := chainhash.NewHash(badRootBytes[:])
+	badRoot, err := lntypes.MakeHash(badRootBytes[:])
 	require.NoError(t, err, "bad merkle root")
 
 	tests := []struct {
@@ -236,7 +236,7 @@ func TestOfferValidation(t *testing.T) {
 				NodeID:      nodePubkey,
 				Description: " ",
 				Signature:   &schnorrSig,
-				MerkleRoot:  *root,
+				MerkleRoot:  root,
 			},
 		},
 		{
@@ -245,7 +245,7 @@ func TestOfferValidation(t *testing.T) {
 				NodeID:      nodePubkey,
 				Description: " ",
 				Signature:   &schnorrSig,
-				MerkleRoot:  *badRoot,
+				MerkleRoot:  badRoot,
 			},
 			err: ErrInvalidOfferSig,
 		},

--- a/lnwire/offer_test.go
+++ b/lnwire/offer_test.go
@@ -247,7 +247,7 @@ func TestOfferValidation(t *testing.T) {
 				Signature:   &schnorrSig,
 				MerkleRoot:  badRoot,
 			},
-			err: ErrInvalidOfferSig,
+			err: ErrInvalidSig,
 		},
 	}
 

--- a/lnwire/onion_msg_payload.go
+++ b/lnwire/onion_msg_payload.go
@@ -26,6 +26,10 @@ const (
 	// InvoiceNamespaceType is a record containing the sub-namespace of
 	// tlvs that describe an invoice.
 	InvoiceNamespaceType tlv.Type = 64
+
+	// InvoiceRequestNamespaceType is a record containing the sub-namespace
+	// of tlvs that request invoices for offers.
+	InvoiceRequestNamespaceType tlv.Type = 66
 )
 
 // ErrNotFinalPayload is returned when a final hop payload is not within the
@@ -103,6 +107,10 @@ func DecodeOnionMessagePayload(o []byte) (*OnionMessagePayload, error) {
 		invoicePayload = &FinalHopPayload{
 			TLVType: InvoiceNamespaceType,
 		}
+
+		invoiceRequestPayload = &FinalHopPayload{
+			TLVType: InvoiceRequestNamespaceType,
+		}
 	)
 
 	records := []tlv.Record{
@@ -116,6 +124,12 @@ func DecodeOnionMessagePayload(o []byte) (*OnionMessagePayload, error) {
 		// here, or decoding will fail. We decode directly into a final
 		// hop payload, so that we can just add it if present later.
 		tlv.MakePrimitiveRecord(InvoiceNamespaceType, &invoicePayload.Value),
+		// Add a record for invoice request sub-namespace so that we
+		// won't fail on the even tlv - reasoning above.
+		tlv.MakePrimitiveRecord(
+			InvoiceRequestNamespaceType,
+			&invoiceRequestPayload.Value,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -168,6 +182,12 @@ func DecodeOnionMessagePayload(o []byte) (*OnionMessagePayload, error) {
 	if _, ok := tlvMap[InvoiceNamespaceType]; ok {
 		onionPayload.FinalHopPayloads = append(
 			onionPayload.FinalHopPayloads, invoicePayload,
+		)
+	}
+
+	if _, ok := tlvMap[InvoiceRequestNamespaceType]; ok {
+		onionPayload.FinalHopPayloads = append(
+			onionPayload.FinalHopPayloads, invoiceRequestPayload,
 		)
 	}
 


### PR DESCRIPTION
* Extract common features / merkle root functions
* Update offers to use `lntypes.Hash`
* Add invoice encoding/decoding
* Add invoice request encoding/decoding