### PR TITLE
Route blinding: Add blinded route selection

### DIFF
--- a/routes/blinded.go
+++ b/routes/blinded.go
@@ -1,7 +1,23 @@
 package routes
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/lndclient"
+	lndwire "github.com/lightningnetwork/lnd/lnwire"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	// ErrNoChannels is returned when we don't have any open channels, so
+	// won't be reachable by onion message.
+	ErrNoChannels = errors.New("can't create blinded route with no " +
+		"channels")
+
 )
 
 // BlindedRouteGenerator produces blinded routes.
@@ -22,3 +38,62 @@ func NewBlindedRouteGenerator(lnd Lnd,
 		pubkey: pubkey,
 	}
 }
+
+// canRelayFunc is the function signature of closures used to check whether a
+// peer can relay onion messages.
+type canRelayFunc func(*lndclient.NodeInfo) error
+
+// getRelayingPeers returns a list of peers that would be suitable for relaying
+// onion messages:
+// 1. We have a channel with the peer: assuming that onion messages will be
+//    predominantly relayed on channel-lines.
+// 2. The channel is active: an active channel indicates that the peer is
+//    online and will likely be able to relay messages.
+// 3. The node satisfies the canRelay closure passed in (provided as a param
+//    for easy testing).
+func getRelayingPeers(ctx context.Context, lnd Lnd,
+	canRelay canRelayFunc) ([]*lndclient.NodeInfo, error) {
+
+	// List all channels (private and inactive) so that we can provide
+	// better error messages.
+	channels, err := lnd.ListChannels(ctx, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("list channels: %w", err)
+	}
+
+	// Assuming that onion messages will only be relayed along
+	// channel-lines, we fail if we have no channels.
+	if len(channels) == 0 {
+		return nil, ErrNoChannels
+	}
+
+	var activePeers []*lndclient.NodeInfo
+	for _, channel := range channels {
+		// Lookup the peer in our graph. Skip over any peers that
+		// aren't found (gossip sync is imperfect), but fail if we
+		// error out otherwise.
+		nodeInfo, err := lnd.GetNodeInfo(ctx, channel.PubKeyBytes, true)
+		if err != nil {
+			// If we don't have an error code, or we have one that
+			// isn't "NotFound" then an unexpected error has
+			// occurred.
+			status, ok := status.FromError(err)
+			if !ok || status.Code() != codes.NotFound {
+				return nil, fmt.Errorf("get node: %w", err)
+			}
+
+			// Log that we're not found.
+			continue
+		}
+
+		if err := canRelay(nodeInfo); err != nil {
+			// log that we can't relay
+			continue
+		}
+
+		activePeers = append(activePeers, nodeInfo)
+	}
+
+	return activePeers, nil
+}
+

--- a/routes/blinded.go
+++ b/routes/blinded.go
@@ -1,0 +1,24 @@
+package routes
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+// BlindedRouteGenerator produces blinded routes.
+type BlindedRouteGenerator struct {
+	// lnd provides access to our lnd node.
+	lnd Lnd
+
+	// pubkey is our node's public key.
+	pubkey *btcec.PublicKey
+}
+
+// NewBlindedRouteGenerator creates a blinded route generator.
+func NewBlindedRouteGenerator(lnd Lnd,
+	pubkey *btcec.PublicKey) *BlindedRouteGenerator {
+
+	return &BlindedRouteGenerator{
+		lnd:    lnd,
+		pubkey: pubkey,
+	}
+}

--- a/routes/blinded.go
+++ b/routes/blinded.go
@@ -46,6 +46,10 @@ type BlindedRouteGenerator struct {
 	pubkey *btcec.PublicKey
 }
 
+// Compile time check that blinded path generator implements the generator
+// interface.
+var _ Generator = (*BlindedRouteGenerator)(nil)
+
 // NewBlindedRouteGenerator creates a blinded route generator.
 func NewBlindedRouteGenerator(lnd Lnd,
 	pubkey *btcec.PublicKey) *BlindedRouteGenerator {

--- a/routes/blinded_test.go
+++ b/routes/blinded_test.go
@@ -1,0 +1,205 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/carlakc/boltnd/testutils"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestGetRelayingPeers tests filtering of peers into a set that can relay
+// onion messages to us.
+func TestGetRelayingPeers(t *testing.T) {
+	var (
+		pubkeys  = testutils.GetPubkeys(t, 2)
+		channel1 = lndclient.ChannelInfo{
+			ChannelID:   1,
+			PubKeyBytes: route.NewVertex(pubkeys[0]),
+		}
+
+		channel1NodeInfo = &lndclient.NodeInfo{
+			Node: &lndclient.Node{
+				PubKey: channel1.PubKeyBytes,
+			},
+		}
+
+		channel2 = lndclient.ChannelInfo{
+			ChannelID:   2,
+			PubKeyBytes: route.NewVertex(pubkeys[1]),
+		}
+
+		channel2NodeInfo = &lndclient.NodeInfo{
+			Node: &lndclient.Node{
+				PubKey: channel2.PubKeyBytes,
+			},
+		}
+
+		mockErr = errors.New("err")
+	)
+
+	tests := []struct {
+		name      string
+		setupMock func(m *mock.Mock)
+		canRelay  func(*lndclient.NodeInfo) error
+		peers     []*lndclient.NodeInfo
+		err       error
+	}{
+		{
+			name: "no active channels",
+			setupMock: func(m *mock.Mock) {
+				testutils.MockListChannels(
+					m, true, false,
+					[]lndclient.ChannelInfo{}, nil,
+				)
+			},
+			err: ErrNoChannels,
+		},
+		{
+			name: "active channels - can't relay",
+			setupMock: func(m *mock.Mock) {
+				testutils.MockListChannels(
+					m, true, false,
+					[]lndclient.ChannelInfo{
+						channel1,
+					}, nil,
+				)
+
+				// Expect our channel's node to be looked up.
+				testutils.MockGetNodeInfo(
+					m, channel1.PubKeyBytes, true,
+					channel1NodeInfo, nil,
+				)
+			},
+			// Return false for all channels.
+			canRelay: func(*lndclient.NodeInfo) error {
+				return errors.New("can't relay")
+			},
+			peers: nil,
+			err:   nil,
+		},
+		{
+			name: "active channels - one can relay",
+			setupMock: func(m *mock.Mock) {
+				// Return two channels.
+				testutils.MockListChannels(
+					m, true, false,
+					[]lndclient.ChannelInfo{
+						channel1, channel2,
+					}, nil,
+				)
+
+				// Prime our mock to find both channels peers.
+				testutils.MockGetNodeInfo(
+					m, channel1.PubKeyBytes, true,
+					channel1NodeInfo, nil,
+				)
+
+				testutils.MockGetNodeInfo(
+					m, channel2.PubKeyBytes, true,
+					channel2NodeInfo, nil,
+				)
+			},
+			// Set our relay filter to only allow channel 1.
+			canRelay: func(info *lndclient.NodeInfo) error {
+				if info.PubKey == channel1.PubKeyBytes {
+					return nil
+				}
+
+				return errors.New("can't relay")
+			},
+			peers: []*lndclient.NodeInfo{
+				channel1NodeInfo,
+			},
+			err: nil,
+		},
+		{
+			name: "channel's node not found",
+			setupMock: func(m *mock.Mock) {
+				// Return two channels.
+				testutils.MockListChannels(
+					m, true, false,
+					[]lndclient.ChannelInfo{
+						channel1, channel2,
+					}, nil,
+				)
+
+				// Prime our mock to lookup the first one
+				// successfully.
+				testutils.MockGetNodeInfo(
+					m, channel1.PubKeyBytes, true,
+					channel1NodeInfo, nil,
+				)
+
+				// Prime our mock to return a not found error
+				// for our second channel.
+				err := status.Error(codes.NotFound, "err str")
+				testutils.MockGetNodeInfo(
+					m, channel2.PubKeyBytes, true,
+					// Our channel array is non-nil so
+					// that the mock can cast this value
+					// without nil-checks.
+					&lndclient.NodeInfo{}, err,
+				)
+			},
+			// Set all peers able to relay.
+			canRelay: func(*lndclient.NodeInfo) error {
+				return nil
+			},
+			// We should succeed with one of our channels despite
+			// not being able to find the other one.
+			peers: []*lndclient.NodeInfo{
+				channel1NodeInfo,
+			},
+			err: nil,
+		},
+		{
+			// Test the case where we get a failure other than
+			// "not found" from GetNodeInfo and ensure that we
+			// error out accordingly.
+			name: "node info failure",
+			setupMock: func(m *mock.Mock) {
+				// Return two channels.
+				testutils.MockListChannels(
+					m, true, false,
+					[]lndclient.ChannelInfo{
+						channel1, channel2,
+					}, nil,
+				)
+
+				// Prime our mock to lookup the first one
+				// successfully.
+				testutils.MockGetNodeInfo(
+					m, channel1.PubKeyBytes, true,
+					&lndclient.NodeInfo{}, mockErr,
+				)
+			},
+			err: mockErr,
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			lnd := testutils.NewMockLnd()
+			defer lnd.AssertExpectations(t)
+
+			testCase.setupMock(lnd.Mock)
+
+			ctx := context.Background()
+			peers, err := getRelayingPeers(
+				ctx, lnd, testCase.canRelay,
+			)
+
+			require.True(t, errors.Is(err, testCase.err))
+			require.Equal(t, testCase.peers, peers)
+		})
+	}
+}

--- a/routes/interface.go
+++ b/routes/interface.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/lightninglabs/lndclient"
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	lndwire "github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
 
@@ -16,4 +18,12 @@ type Lnd interface {
 	// GetNodeInfo looks up a node in the public ln graph.
 	GetNodeInfo(ctx context.Context, pubkey route.Vertex,
 		includeChannels bool) (*lndclient.NodeInfo, error)
+}
+
+// Generator is an interface implemented by blinded route producers.
+type Generator interface {
+	// BlindedRoute produces a blinded route to our node with the set of
+	// features requested.
+	BlindedRoute(ctx context.Context,
+		features []lndwire.FeatureBit) (*sphinx.BlindedPath, error)
 }

--- a/routes/interface.go
+++ b/routes/interface.go
@@ -1,0 +1,19 @@
+package routes
+
+import (
+	"context"
+
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// Lnd describes the lnd dependencies required to find a route.
+type Lnd interface {
+	// ListChannels lists our current set of channels.
+	ListChannels(ctx context.Context, activeOnly,
+		publicOnly bool) ([]lndclient.ChannelInfo, error)
+
+	// GetNodeInfo looks up a node in the public ln graph.
+	GetNodeInfo(ctx context.Context, pubkey route.Vertex,
+		includeChannels bool) (*lndclient.NodeInfo, error)
+}

--- a/testutils/blinded_routes.go
+++ b/testutils/blinded_routes.go
@@ -1,0 +1,42 @@
+package testutils
+
+import (
+	"context"
+
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	lndwire "github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockRouteGenerator creates a mock that substitutes for blinded route
+// generation.
+type MockRouteGenerator struct {
+	*mock.Mock
+}
+
+// NewMockRouteGenerator produces a mock for blinded path generation.
+func NewMockRouteGenerator() *MockRouteGenerator {
+	return &MockRouteGenerator{
+		Mock: &mock.Mock{},
+	}
+}
+
+// BlindedRoute mocks creation of a blinded route.
+func (m *MockRouteGenerator) BlindedRoute(ctx context.Context,
+	features []lndwire.FeatureBit) (*sphinx.BlindedPath, error) {
+
+	args := m.Mock.MethodCalled("BlindedRoute", ctx, features)
+	return args.Get(0).(*sphinx.BlindedPath), args.Error(1)
+}
+
+// MockBlindedRoute primes our mock to return the error provided when
+// send custom message is called with any CustomMessage.
+func MockBlindedRoute(m *mock.Mock, features []lndwire.FeatureBit,
+	path *sphinx.BlindedPath, err error) {
+
+	m.On(
+		"BlindedRoute", mock.Anything, features,
+	).Once().Return(
+		path, err,
+	)
+}

--- a/testutils/lnd.go
+++ b/testutils/lnd.go
@@ -172,3 +172,27 @@ func MockDeriveSharedKey(m *mock.Mock, ephemeral *btcec.PublicKey,
 		key, err,
 	)
 }
+
+// ListChannels mocks a call to lnd's list channels api.
+func (m *MockLND) ListChannels(ctx context.Context, activeOnly,
+	publicOnly bool) ([]lndclient.ChannelInfo, error) {
+
+	args := m.Mock.MethodCalled(
+		"ListChannels", ctx, activeOnly, publicOnly,
+	)
+
+	channels := args.Get(0).([]lndclient.ChannelInfo)
+	return channels, args.Error(1)
+}
+
+// MockListChannels primes our mock to return the channel list and error
+// provided when ListChannels is called.
+func MockListChannels(m *mock.Mock, activeOnly, publicOnly bool,
+	channels []lndclient.ChannelInfo, err error) {
+
+	m.On(
+		"ListChannels", mock.Anything, activeOnly, publicOnly,
+	).Once().Return(
+		channels, err,
+	)
+}


### PR DESCRIPTION
This is an incredibly lazy drop in to produce a blinded route:
* Introduction Node: our peer with the most channels (should be reachable)
* Hop 1: our node
