### PR TITLE
lnwire: serialize payer key as `point32`

### DIFF
--- a/lnwire/bolt12_invoice_request_test.go
+++ b/lnwire/bolt12_invoice_request_test.go
@@ -24,6 +24,13 @@ func TestInvoiceRequestEncoding(t *testing.T) {
 		sig [64]byte
 	)
 
+	xOnlyPubkey, err := schnorr.ParsePubKey(
+		schnorr.SerializePubKey(
+			pubkey,
+		),
+	)
+	require.NoError(t, err, "schnorr pubkey")
+
 	copy(hash[:], []byte{1, 2, 3})
 	copy(sig[:], []byte{4, 5, 6})
 
@@ -54,7 +61,7 @@ func TestInvoiceRequestEncoding(t *testing.T) {
 			encoded: &InvoiceRequest{
 				// Include a non-empty record so that our merkle
 				// tree can be calculated on decode.
-				PayerKey: pubkey,
+				PayerKey: xOnlyPubkey,
 				Features: lnwire.NewFeatureVector(
 					lnwire.NewRawFeatureVector(),
 					lnwire.Features,
@@ -81,7 +88,7 @@ func TestInvoiceRequestEncoding(t *testing.T) {
 		{
 			name: "payer key",
 			encoded: &InvoiceRequest{
-				PayerKey: pubkey,
+				PayerKey: xOnlyPubkey,
 			},
 		},
 		{
@@ -101,7 +108,7 @@ func TestInvoiceRequestEncoding(t *testing.T) {
 			encoded: &InvoiceRequest{
 				// Include a non-sig record so that our merkle
 				// tree can be calculated on decode.
-				PayerKey:  pubkey,
+				PayerKey:  xOnlyPubkey,
 				Signature: &sig,
 			},
 		},


### PR DESCRIPTION
Note: the spec has been updated to require a `point`, but CL currently
implements a `point32`, so this change updates our lnwire to be able
to test against CL.