### PR TITLE
onionmsg: fix regression in multi-hop onion messages

### DIFF
--- a/itest/common.go
+++ b/itest/common.go
@@ -80,7 +80,12 @@ func readOnionMessage(msgChan chan *offersrpc.SubscribeOnionPayloadResponse,
 		// In the case of a timeout, let our test exit. This will
 		// cancel the receive goroutine (through context cancelation)
 		// and wait for it to exit.
-		case <-time.After(defaultTimeout):
+		//
+		// We allow messages up to a minute to arrive because lnd uses
+		// low priority for custom messages, so our messages may be
+		// queued for a while before they arrive. Increasing this to
+		// a minute decreases test flakes significantly.
+		case <-time.After(time.Minute):
 			return nil, errors.New("message read timeout")
 		}
 	}

--- a/onionmsg/messenger.go
+++ b/onionmsg/messenger.go
@@ -389,7 +389,7 @@ func (m *Messenger) SendMessage(ctx context.Context,
 
 	// Finally, convert this onion message to a custom message so that we
 	// can sent it via lnd's custom message API.
-	msg, err := customOnionMessage(req.Peer, onionMsg)
+	msg, err := customOnionMessage(path[0], onionMsg)
 	if err != nil {
 		return fmt.Errorf("could not create custom message: %w", err)
 	}


### PR DESCRIPTION
* Regression introduced in f4068d1c5dfe5054d72d6433765161f25907986b
* Increase timeout to allow for lnd's lazy send of custom messages