### PR TITLE
lnwire: add hop count to reply path encoding

### DIFF
--- a/routes/blinded_test.go
+++ b/routes/blinded_test.go
@@ -506,6 +506,11 @@ func TestBlindedToSphinx(t *testing.T) {
 		replyPath = &lnwire.ReplyPath{
 			FirstNodeID:   pubkeys[0],
 			BlindingPoint: pubkeys[1],
+			Hops: []*lnwire.BlindedHop{
+				{
+					BlindedNodeID: pubkeys[2],
+				},
+			},
 		}
 
 		onion1WithReplyPath = &lnwire.OnionMessagePayload{


### PR DESCRIPTION
Newer versions of the specification prefix reply path hops with their count. This simplifies encoding / decoding nicely because you don't need to count the number of bytes left to figure out whether there are more hops to go. 